### PR TITLE
Remove travis indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-pubchem-utils [![Build Status](https://travis-ci.org/skearnes/pubchem-utils.svg?branch=master)](https://travis-ci.org/skearnes/pubchem-utils)
+pubchem-utils
 =============
 
 Utilities for interacting with [PubChem](https://pubchem.ncbi.nlm.nih.gov)


### PR DESCRIPTION
The tests sometimes fail and then pass on a re-run. Rather than display "passing", I will remove the indicator until I can write better tests.